### PR TITLE
HP-2505: improve ticket template view styling and truncate long titles

### DIFF
--- a/src/grid/TemplateGridView.php
+++ b/src/grid/TemplateGridView.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * HiPanel tickets module
  *
@@ -29,9 +31,7 @@ class TemplateGridView extends \hipanel\grid\BoxedGridView
                 'nameAttribute' => 'author',
             ],
             'post_date' => [
-                'value' => function ($model) {
-                    return Yii::$app->formatter->asDatetime($model->post_date);
-                },
+                'value' => fn($model): string => $this->formatter->asDatetime($model->post_date),
             ],
             'actions' => [
                 'class' => MenuColumn::class,
@@ -46,6 +46,7 @@ class TemplateGridView extends \hipanel\grid\BoxedGridView
             'name' => [
                 'class' => MainColumn::class,
                 'filterAttribute' => 'name_like',
+                'contentOptions' => ['style' => 'white-space: break-spaces;'],
             ],
         ]);
     }

--- a/src/views/template/view.php
+++ b/src/views/template/view.php
@@ -6,6 +6,7 @@ use hipanel\modules\ticket\menus\TemplateDetailMenu;
 use hipanel\modules\ticket\models\Template;
 use hipanel\widgets\Box;
 use yii\helpers\Html;
+use yii\helpers\StringHelper;
 use yii\web\View;
 
 /**
@@ -15,7 +16,7 @@ use yii\web\View;
 
 $this->title = $model->name;
 $this->params['breadcrumbs'][] = ['label' => Yii::t('hipanel:ticket', 'Answer templates'), 'url' => ['index']];
-$this->params['breadcrumbs'][] = $this->title;
+$this->params['breadcrumbs'][] = StringHelper::truncateWords($this->title, 6);
 
 ?>
 
@@ -40,7 +41,7 @@ $this->params['breadcrumbs'][] = $this->title;
             <?= TemplateDetailMenu::widget(['model' => $model]) ?>
         </div>
         <?php Box::end() ?>
-            <?php $box = Box::begin(['renderBody' => false]) ?>
+            <?php $box = Box::begin(['renderBody' => false, 'bodyOptions' => ['class' => 'table-responsive no-padding']]) ?>
             <?php $box->beginHeader() ?>
                 <?= $box->renderTitle(Yii::t('hipanel:ticket', 'Template details')) ?>
             <?php $box->endHeader() ?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved display of the name column in the grid by enabling breaking spaces for better readability.
  * Enhanced the styling and responsiveness of the template details section for a better viewing experience.

* **New Features**
  * Breadcrumb titles are now truncated to a maximum of six words for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->