### PR TITLE
HP-2618: refactor thread comment handling

### DIFF
--- a/src/views/ticket/_rightBlock.php
+++ b/src/views/ticket/_rightBlock.php
@@ -2,6 +2,7 @@
 
 use hipanel\helpers\Url;
 use hipanel\modules\ticket\assets\ThreadCheckerAsset;
+use hipanel\modules\ticket\widgets\ThreadDecorator;
 use hipanel\widgets\AjaxModal;
 use yii\bootstrap\Modal;
 use yii\helpers\Html;
@@ -10,9 +11,9 @@ use yii\web\JsExpression;
 use yii\web\View;
 
 /**
- * @var View
+ * @var View $this
  * @var \hipanel\modules\ticket\models\Thread $model
- * @var \hipanel\modules\ticket\widgets\ThreadDecorator $decorator
+ * @var ThreadDecorator $decorator
  */
 ThreadCheckerAsset::register($this);
 
@@ -23,17 +24,24 @@ $threadCheckerOptions = Json::encode([
 ]);
 
 $this->registerJs(<<<JS
+function openCommentForm (event) {
+  var button = $(event.currentTarget);
+  var comments_form = $('.leave-comment-form');
+  var comment_tab_sibling = comments_form.prev();
+
+  button.after(comments_form);
+  comment_tab_sibling.after(button);
+  comments_form.find('textarea').focus().trigger('focus');
+}
+
 $('.widget-article-comments').threadChecker($threadCheckerOptions);
 
-$('.message-block-move-btn').on('click', function () {
-    var button = $(this);
-    var comments_form = $('.leave-comment-form');
-    var comment_tab_sibling = comments_form.prev();
+$('.message-block-move-btn').on('click', openCommentForm);
 
-    button.after(comments_form);
-    comment_tab_sibling.after(button);
-    comments_form.find('textarea').focus().trigger('focus');
-});
+const messageElement = document.getElementById('thread-message');
+if (typeof openCommentForm !== 'undefined' && messageElement && messageElement.value) {
+  $('.message-block-move-btn').click();
+}
 
 $(".comment-quote-button").on("click", function(event) {
     event.preventDefault();
@@ -59,7 +67,8 @@ $(".comment-quote-button").on("click", function(event) {
     });
 });
 JS
-    , View::POS_READY);
+    , View::POS_LOAD);
+
 ?>
 
 <div class="box box-widget">


### PR DESCRIPTION
Force open answer block if the user press the back button and the error has occurred (400 bad requests) after sending the form. The problem occurs if the CSRF token has already changed and the form is sent with the old CSRF token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * The comment form now opens automatically if you have already started typing a message when the page loads.

* **Improvements**
  * Enhanced the logic for opening and focusing the comment form, making it more responsive to user actions.
  * Adjusted the timing of script execution to ensure smoother page interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->