### PR TITLE
HP-2724: update CSRF token in threadChecker after receiving response …

### DIFF
--- a/src/assets/js/threadChecker.js
+++ b/src/assets/js/threadChecker.js
@@ -59,6 +59,9 @@
             if (data.html) {
                 this.element.html(data.html);
             }
+            if ("csrf" in data) {
+              $('#leave-comment-form').find('input[name="_csrf"]').val(data.csrf);
+            }
         }
     };
 

--- a/src/controllers/TicketController.php
+++ b/src/controllers/TicketController.php
@@ -399,7 +399,7 @@ class TicketController extends \hipanel\base\CrudController
     {
         Yii::$app->response->format = Response::FORMAT_JSON;
 
-        $result = ['id' => $id, 'answer_id' => $answer_id];
+        $result = ['id' => $id, 'answer_id' => $answer_id, 'csrf' => Yii::$app->request->csrfToken];
 
         try {
             $data = Thread::perform('get-last-answer-id', ['id' => $id, 'answer_id' => $answer_id]);


### PR DESCRIPTION
…from `get-new-answers` to prevent 400 error CSRF token is invalid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents occasional CSRF-related errors when submitting comments after new answers load dynamically.
  * Keeps the comment form’s security token in sync during live thread updates, ensuring smoother posting.
  * Improves reliability of asynchronous updates without disrupting existing page behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->