### PR TITLE
HP-2830: Set topic and responsible by default

### DIFF
--- a/src/views/ticket/_form.php
+++ b/src/views/ticket/_form.php
@@ -183,7 +183,7 @@ $('#{$form->getId()} textarea').one('focus', function(event) {
                     <div class="col-md-3">
                         <div class="pull-right">
                             <?php if (!$model->isNewRecord && Yii::$app->user->can('owner-staff')) : ?>
-                                <?php $model->topics ??= 'technical' ?>
+                                <?php $model->topics = empty($model->topics) ? 'technical' : array_keys($model->topics) ?>
                                 <?= $form->field($model, 'responsible')->widget(ClientCombo::class, [
                                     'clientType' => $model->getResponsibleClientTypes(),
                                 ]) ?>

--- a/src/views/ticket/_form.php
+++ b/src/views/ticket/_form.php
@@ -183,7 +183,10 @@ $('#{$form->getId()} textarea').one('focus', function(event) {
                     <div class="col-md-3">
                         <div class="pull-right">
                             <?php if (!$model->isNewRecord && Yii::$app->user->can('owner-staff')) : ?>
-                                <?php $model->topics = empty($model->topics) ? ['technical'] : array_keys($model->topics) ?>
+                                <?php $topics = array_keys($model->topics ?? [] ) ?>
+                                <?php if (!empty(Yii::$app->params['module.ticket.default.topics'])): ?>
+                                    <?php $topics = $topics ?: Yii::$app->params['module.ticket.default.topics'] ?>
+                                <?php endif ?>
                                 <?php $model->responsible ??= Yii::$app->user->getIdentity()->username ?>
                                 <?= $form->field($model, 'responsible')->widget(ClientCombo::class, [
                                     'clientType' => $model->getResponsibleClientTypes(),
@@ -192,6 +195,9 @@ $('#{$form->getId()} textarea').one('focus', function(event) {
                                     'hasId' => true,
                                     'data' => $topic_data ?? [],
                                     'multiple' => true,
+                                    'inputOptions' => [
+                                        'value' => $topics,
+                                    ],
                                 ]) ?>
                             <?php endif ?>
                         </div>

--- a/src/views/ticket/_form.php
+++ b/src/views/ticket/_form.php
@@ -183,7 +183,8 @@ $('#{$form->getId()} textarea').one('focus', function(event) {
                     <div class="col-md-3">
                         <div class="pull-right">
                             <?php if (!$model->isNewRecord && Yii::$app->user->can('owner-staff')) : ?>
-                                <?php $model->topics = empty($model->topics) ? 'technical' : array_keys($model->topics) ?>
+                                <?php $model->topics = empty($model->topics) ? ['technical'] : array_keys($model->topics) ?>
+                                <?php $model->responsible ??= Yii::$app->user->getIdentity()->username ?>
                                 <?= $form->field($model, 'responsible')->widget(ClientCombo::class, [
                                     'clientType' => $model->getResponsibleClientTypes(),
                                 ]) ?>

--- a/src/views/ticket/_form.php
+++ b/src/views/ticket/_form.php
@@ -5,6 +5,8 @@ use hipanel\modules\ticket\models\Answer;
 use hipanel\modules\ticket\models\Thread;
 use hipanel\modules\ticket\widgets\ConditionalFormWidget;
 use hipanel\modules\ticket\widgets\TemplatesWidget;
+use hipanel\modules\client\widgets\combo\ClientCombo;
+use hiqdev\combo\StaticCombo;
 use hipanel\widgets\FileInput;
 use hipanel\widgets\TimePicker;
 use hipanel\assets\CheckboxStyleAsset;
@@ -171,11 +173,29 @@ $('#{$form->getId()} textarea').one('focus', function(event) {
                             </div>
                         <?php endif; ?>
                     </div>
-                    <div class="col-md-7">
+                    <div class="col-md-3">
                         <div class="pull-right">
                             <?php if (!$model->isNewRecord && $model->isAttributeActive('is_private') && Yii::$app->user->can('ticket.set-private')) : ?>
                                 <?= $form->field($model, 'is_private')->checkbox(['class' => 'option-input']) ?>
                             <?php endif; ?>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div class="pull-right">
+                            <?php if (!$model->isNewRecord) : ?>
+                                <?php // $model->responsible = $model->responsible ?? Yii::$app->user->username ?>
+                                <?= $form->field($model, 'responsible')->widget(ClientCombo::class, [
+                                    'clientType' => $model->getResponsibleClientTypes(),
+                                ]) ?>
+                                <?= $form->field($model, 'topics')->widget(StaticCombo::class, [
+                                    'hasId' => true,
+                                    'data' => $topic_data ?? [],
+                                    'multiple' => true,
+                                    'inputOptions' => [
+                                        'value' => 'technical',
+                                    ],
+                                ]) ?>
+                            <?php endif ?>
                         </div>
                     </div>
                 </div>

--- a/src/views/ticket/_form.php
+++ b/src/views/ticket/_form.php
@@ -182,8 +182,8 @@ $('#{$form->getId()} textarea').one('focus', function(event) {
                     </div>
                     <div class="col-md-3">
                         <div class="pull-right">
-                            <?php if (!$model->isNewRecord) : ?>
-                                <?php // $model->responsible = $model->responsible ?? Yii::$app->user->username ?>
+                            <?php if (!$model->isNewRecord && Yii::$app->user->can('owner-staff')) : ?>
+                                <?php $model->topics ??= 'technical' ?>
                                 <?= $form->field($model, 'responsible')->widget(ClientCombo::class, [
                                     'clientType' => $model->getResponsibleClientTypes(),
                                 ]) ?>
@@ -191,9 +191,6 @@ $('#{$form->getId()} textarea').one('focus', function(event) {
                                     'hasId' => true,
                                     'data' => $topic_data ?? [],
                                     'multiple' => true,
-                                    'inputOptions' => [
-                                        'value' => 'technical',
-                                    ],
                                 ]) ?>
                             <?php endif ?>
                         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Responsible" field to ticket forms (visible to owner-staff on existing tickets).
  * Added "Topics" multi-select field to ticket forms with preloaded values.
  * Topics now default from system ticket defaults when none are set.
  * Responsible now defaults to the current user's username when unset.
  * Updated ticket form layout and block arrangement to accommodate the new controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->