### PR TITLE
HQD-79: delete responsible selector in form

### DIFF
--- a/src/views/ticket/_advancedForm.php
+++ b/src/views/ticket/_advancedForm.php
@@ -16,6 +16,7 @@ use yii\widgets\DetailView;
 
 $user = Yii::$app->user->identity;
 $isSupport = Yii::$app->user->can('access-subclients') && !Yii::$app->user->identity->is('client');
+$isOwnerStaff = $isSupport && Yii::$app->user->can('owner-staff');
 $isNewRecord = $model->isNewRecord;
 
 if ($isNewRecord) {
@@ -81,7 +82,7 @@ $this->registerCss(".table.detail-view { margin-bottom: 0px; }");
                     ],
                 ]),
             ] : null,
-            $isSupport ? [
+            $isOwnerStaff ? [
                 'attribute' => 'responsible',
                 'format' => 'raw',
                 'value' => $isNewRecord ? $form->field($model, 'responsible')->widget(ClientCombo::class, [

--- a/src/views/ticket/_form.php
+++ b/src/views/ticket/_form.php
@@ -187,10 +187,6 @@ $('#{$form->getId()} textarea').one('focus', function(event) {
                                 <?php if (!empty(Yii::$app->params['module.ticket.default.topics'])): ?>
                                     <?php $topics = $topics ?: Yii::$app->params['module.ticket.default.topics'] ?>
                                 <?php endif ?>
-                                <?php $model->responsible ??= Yii::$app->user->getIdentity()->username ?>
-                                <?= $form->field($model, 'responsible')->widget(ClientCombo::class, [
-                                    'clientType' => $model->getResponsibleClientTypes(),
-                                ]) ?>
                                 <?= $form->field($model, 'topics')->widget(StaticCombo::class, [
                                     'hasId' => true,
                                     'data' => $topic_data ?? [],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Permissions & Access Control**
  * Restricted access to the "responsible" field to staff members with specific owner-staff permissions.
  * Removed the "responsible" field from the main ticket form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->