### PR TITLE
Fix TicketSidebarMenuCest: admin should see Tickets statistics

### DIFF
--- a/tests/acceptance/admin/TicketSidebarMenuCest.php
+++ b/tests/acceptance/admin/TicketSidebarMenuCest.php
@@ -13,9 +13,7 @@ class TicketSidebarMenuCest
         $menu->ensureContains('Support', [
             'Tickets' => '@ticket/index',
             'Templates' => '@ticket/template/index',
-        ]);
-        $menu->ensureDoesNotContain('Support', [
-            'Tickets statistics',
+            'Tickets statistics' => '/ticket/statistic/index',
         ]);
     }
 }


### PR DESCRIPTION
The test asserted admin must NOT see "Tickets statistics" in the sidebar, but hipanel-rbac's role tree grants it: role:admin includes role:support, which includes role:ticket.manager, which grants ticket.read-statistics - the exact permission SidebarMenu checks via Yii::\$app->user->can() to show this item. The test was stale relative to the RBAC hierarchy; admin inheriting support's ticket-management capabilities is intentional, not a bug. Updated to assert the item is present, matching the pattern already used in the seller variant of this same test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated acceptance coverage to reflect the “Tickets statistics” item in the Support sidebar menu.
  * Verified that the menu item links to the ticket statistics page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->